### PR TITLE
Fix Unsplash Source API URLs

### DIFF
--- a/css/header.css
+++ b/css/header.css
@@ -2,7 +2,7 @@
 #body-settings #header,
 #body-public #header {
     background-color    : #777 !important;
-    background-image    : url('https://source.unsplash.com/random/featured/?nature') !important;
+    background-image    : url('https://source.unsplash.com/featured/?nature') !important;
     background-position : center;
     background-repeat   : no-repeat;
     background-size     : cover;

--- a/css/login.css
+++ b/css/login.css
@@ -1,7 +1,7 @@
 /* Needs more specificity to override theming app */
 body#body-login {
     background-color    : #777 !important;
-    background-image    : url('https://source.unsplash.com/random/featured/?nature') !important;
+    background-image    : url('https://source.unsplash.com/featured/?nature') !important;
     background-position : center;
     background-repeat   : no-repeat;
     background-size     : cover;


### PR DESCRIPTION
Fixes #59 

As explained in [my comment on the issue](https://github.com/nextcloud/unsplash/issues/59#issuecomment-636537511), the URLs are currently not properly formatted, and the `featured` route is ignored.

And while we're looking into the Unsplash Source API, I'm also wondering whether the image should be completely random (i.e. a new one on each page load), or if we should use the the `daily` route show a new image every day instead. Happy to hear your thoughts about this 🙂 