### PR TITLE
[#72] Add workaround for unsplash api issue

### DIFF
--- a/css/header.css
+++ b/css/header.css
@@ -2,7 +2,7 @@
 #body-settings #header,
 #body-public #header {
     background-color    : #777 !important;
-    background-image    : url('https://source.unsplash.com/featured/?nature') !important;
+    background-image    : url('https://source.unsplash.com/featured/?nature,nature') !important;
     background-position : center;
     background-repeat   : no-repeat;
     background-size     : cover;

--- a/css/login.css
+++ b/css/login.css
@@ -1,7 +1,7 @@
 /* Needs more specificity to override theming app */
 body#body-login {
     background-color    : #777 !important;
-    background-image    : url('https://source.unsplash.com/featured/?nature') !important;
+    background-image    : url('https://source.unsplash.com/featured/?nature,nature') !important;
     background-position : center;
     background-repeat   : no-repeat;
     background-size     : cover;


### PR DESCRIPTION
This PR aims to work around the issue that url `https://source.unsplash.com/featured/?nature` does not work anymore by adding a second "nature"