### PR TITLE
#80 Restore compatibility with Nextcloud 14 - 19

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -27,6 +27,7 @@
     </dependencies>
     <settings>
         <admin>OCA\Unsplash\Settings\AdminSettings</admin>
-        <personal>\OCA\Unsplash\Settings\PersonalSettings</personal>
+        <personal>OCA\Unsplash\Settings\PersonalSettings</personal>
+        <personal-section>OCA\Unsplash\Settings\PersonalSection</personal-section>
     </settings>
 </info>

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -1,3 +1,3 @@
 #app-dashboard {
-    background-image : url("https://source.unsplash.com/featured/?nature") !important;
+    background-image : url("https://source.unsplash.com/featured/?nature,nature") !important;
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -8,6 +8,7 @@ namespace OCA\Unsplash\AppInfo;
 
 use OCA\Unsplash\EventListener\AddContentSecurityPolicyEventListener;
 use OCA\Unsplash\EventListener\BeforeTemplateRenderedEventListener;
+use OCA\Unsplash\Services\LegacyInitialisationService;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -31,26 +32,19 @@ class Application extends App {
     }
 
     /**
-     * Register app functionality
-     */
-    public function register() {
-        $this->registerPersonalSettings();
-    }
-
-    /**
      *
      */
     protected function registerSystemEvents() {
-        /* @var IEventDispatcher $eventDispatcher */
-        $dispatcher = $this->getContainer()->get(IEventDispatcher::class);
-        $dispatcher->addServiceListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedEventListener::class);
-        $dispatcher->addServiceListener(AddContentSecurityPolicyEvent::class, AddContentSecurityPolicyEventListener::class);
-    }
-
-    /**
-     * Add the personal settings page
-     */
-    public function registerPersonalSettings() {
-        \OCP\App::registerPersonal('unsplash', 'templates/personal');
+        $container = $this->getContainer();
+        if(method_exists($container, 'get')) {
+            /* @var IEventDispatcher $eventDispatcher */
+            $dispatcher = $this->getContainer()->get(IEventDispatcher::class);
+            $dispatcher->addServiceListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedEventListener::class);
+            $dispatcher->addServiceListener(AddContentSecurityPolicyEvent::class, AddContentSecurityPolicyEventListener::class);
+        } else {
+            /** @var LegacyInitialisationService $service */
+            $service = $this->getContainer()->query(LegacyInitialisationService::class);
+            $service->initialize();
+        }
     }
 }

--- a/lib/Services/LegacyInitialisationService.php
+++ b/lib/Services/LegacyInitialisationService.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * This file is part of the Unpslash App
+ * and licensed under the AGPL.
+ */
+
+namespace OCA\Unsplash\Services;
+
+use OC\Security\CSP\ContentSecurityPolicy;
+use OCP\Security\IContentSecurityPolicyManager;
+use OCP\Util;
+
+/**
+ * Class LegacyInitialisationService
+ *
+ * @package OCA\Unsplash\Services
+ */
+class LegacyInitialisationService {
+
+    /**
+     * @var SettingsService
+     */
+    protected $settingsService;
+
+    /**
+     * @var IContentSecurityPolicyManager
+     */
+    protected $contentSecurityPolicyManager;
+
+    /**
+     * LegacyInitialisationService constructor.
+     *
+     * @param SettingsService               $settingsService
+     * @param IContentSecurityPolicyManager $contentSecurityPolicyManager
+     */
+    public function __construct(SettingsService $settingsService, IContentSecurityPolicyManager $contentSecurityPolicyManager) {
+        $this->settingsService = $settingsService;
+        $this->contentSecurityPolicyManager = $contentSecurityPolicyManager;
+    }
+
+    /**
+     *
+     */
+    public function initialize() {
+        $this->registerStyleSheets();
+        $this->registerCsp();
+    }
+
+    /**
+     * Add the stylesheets
+     */
+    protected function registerStyleSheets() {
+        if($this->settingsService->getUserStyleHeaderEnabled()) {
+            Util::addStyle('unsplash', 'header');
+        }
+        if($this->settingsService->getServerStyleLoginEnabled()) {
+            Util::addStyle('unsplash', 'login');
+        }
+    }
+
+    /**
+     * Allow Unsplash hosts in the csp
+     */
+    protected function registerCsp() {
+        if($this->settingsService->getUserStyleHeaderEnabled() || $this->settingsService->getServerStyleLoginEnabled()) {
+            $policy  = new ContentSecurityPolicy();
+            $policy->addAllowedImageDomain('https://source.unsplash.com');
+            $policy->addAllowedImageDomain('https://images.unsplash.com');
+            $this->contentSecurityPolicyManager->addDefaultPolicy($policy);
+        }
+    }
+}

--- a/lib/Services/SettingsService.php
+++ b/lib/Services/SettingsService.php
@@ -156,4 +156,13 @@ class SettingsService {
         $this->config->setAppValue($this->appName, self::STYLE_LOGIN, $styleLogin);
     }
 
+    /**
+     * @return int
+     */
+    public function getNextcloudVersion(): int {
+        $version = $this->config->getSystemValue('version', '0.0.0');
+        $parts = explode('.', $version, 2);
+
+        return intval($parts[0]);
+    }
 }

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -47,7 +47,8 @@ class AdminSettings implements ISettings {
             'saveSettingsUrl' => $this->urlGenerator->linkToRouteAbsolute('unsplash.admin_settings.set'),
             'styleLogin'      => $this->settings->getServerStyleLoginEnabled(),
             'styleHeader'     => $this->settings->getServerStyleHeaderEnabled(),
-            'styleDashboard'  => $this->settings->getServerStyleDashboardEnabled()
+            'styleDashboard'  => $this->settings->getServerStyleDashboardEnabled(),
+            'hasDashboard'    => $this->settings->getNextcloudVersion() > 19
         ]);
     }
 

--- a/lib/Settings/PersonalSection.php
+++ b/lib/Settings/PersonalSection.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the Unpslash App
+ * and licensed under the AGPL.
+ */
+
+namespace OCA\Unsplash\Settings;
+
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Settings\IIconSection;
+
+/**
+ * Class PersonalSection
+ *
+ * @package OCA\Unsplash\Settings
+ */
+class PersonalSection implements IIconSection {
+
+    /**
+     * @var IURLGenerator
+     */
+    protected $urlGenerator;
+
+    /**
+     * @var IL10N
+     */
+    protected $localisation;
+
+    /**
+     * @var
+     */
+    protected $appName;
+
+    /**
+     * AdminSection constructor.
+     *
+     * @param IL10N         $localisation
+     * @param IURLGenerator $urlGenerator
+     * @param               $appName
+     */
+    public function __construct(IL10N $localisation, IURLGenerator $urlGenerator, $appName) {
+        $this->localisation = $localisation;
+        $this->urlGenerator = $urlGenerator;
+        $this->appName      = $appName;
+    }
+
+    /**
+     * Returns the relative path to an 16*16 icon describing the section.
+     * e.g. '/core/img/places/files.svg'
+     *
+     * @returns string
+     * @since 12
+     */
+    public function getIcon(): string {
+        return $this->urlGenerator->imagePath($this->appName, 'app-dark.svg');
+    }
+
+    /**
+     * Returns the ID of the section. It is supposed to be a lower case string,
+     * e.g. 'passwords'
+     *
+     * @returns string
+     * @since 9.1
+     */
+    public function getID(): string {
+        return $this->appName;
+    }
+
+    /**
+     * Returns the translated name as it should be displayed, e.g. 'Splash'.
+     * Use the L10N service to translate it.
+     *
+     * @return string
+     * @since 9.1
+     */
+    public function getName(): string {
+        return $this->localisation->t('Splash');
+    }
+
+    /**
+     * @return int whether the form should be rather on the top or bottom of
+     * the settings navigation. The sections are arranged in ascending order of
+     * the priority values. It is required to return a value between 0 and 99.
+     *
+     * E.g.: 70
+     * @since 9.1
+     */
+    public function getPriority(): int {
+        return 50;
+    }
+}

--- a/lib/Settings/PersonalSettings.php
+++ b/lib/Settings/PersonalSettings.php
@@ -35,16 +35,23 @@ class PersonalSettings implements ISettings {
     protected $theming;
 
     /**
+     * @var string
+     */
+    protected $appName;
+
+    /**
      * AdminSection constructor.
      *
      * @param IURLGenerator   $urlGenerator
      * @param SettingsService $settings
      * @param OC_Defaults     $theming
+     * @param                 $appName
      */
-    public function __construct(IURLGenerator $urlGenerator, SettingsService $settings, OC_Defaults $theming) {
+    public function __construct(IURLGenerator $urlGenerator, SettingsService $settings, OC_Defaults $theming, $appName) {
         $this->urlGenerator = $urlGenerator;
         $this->settings     = $settings;
         $this->theming      = $theming;
+        $this->appName      = $appName;
     }
 
     /**
@@ -58,14 +65,21 @@ class PersonalSettings implements ISettings {
             'saveSettingsUrl' => $this->urlGenerator->linkToRouteAbsolute('unsplash.personal_settings.set'),
             'styleHeader'     => $this->settings->getUserStyleHeaderEnabled(),
             'styleDashboard'  => $this->settings->getUserStyleDashboardEnabled(),
+            'hasDashboard'    => $this->settings->getNextcloudVersion() > 19,
             'label'           => $this->theming->getEntity()
         ], '');
     }
 
+    /**
+     * @return string
+     */
     public function getSection() {
-        return 'additional';
+        return $this->appName;
     }
 
+    /**
+     * @return int
+     */
     public function getPriority(): int {
         return 75;
     }

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -27,9 +27,11 @@ style('unsplash', 'settings');
             <input id="unsplash-style-header" name="unsplash-style-header" data-setting="style/header" type="checkbox" <?=$_['styleHeader'] ? 'checked':''?> class="checkbox">
             <label for="unsplash-style-header"><?php p($l->t('Set random image as header background')); ?></label>
         </div>
+        <?php if($_['hasDashboard']): ?>
         <div>
             <input id="unsplash-style-dashboard" name="unsplash-style-dashboard" data-setting="style/dashboard" type="checkbox" <?=$_['styleDashboard'] ? 'checked':''?> class="checkbox">
             <label for="unsplash-style-dashboard"><?php p($l->t('Set random image as dashboard background')); ?></label>
         </div>
+        <?php endif; ?>
     </form>
 </div>

--- a/templates/settings/personal.php
+++ b/templates/settings/personal.php
@@ -23,9 +23,11 @@ style('unsplash', 'settings');
             <input id="unsplash-style-header" name="unsplash-style-header" data-setting="style/header" type="checkbox" <?=$_['styleHeader'] ? 'checked':''?> class="checkbox">
             <label for="unsplash-style-header"><?php p($l->t('Set random image as header background')); ?></label>
         </div>
+        <?php if($_['hasDashboard']): ?>
         <div>
             <input id="unsplash-style-dashboard" name="unsplash-style-dashboard" data-setting="style/dashboard" type="checkbox" <?=$_['styleDashboard'] ? 'checked':''?> class="checkbox">
             <label for="unsplash-style-dashboard"><?php p($l->t('Set random image as dashboard background')); ?></label>
         </div>
+        <?php endif; ?>
     </form>
 </div>


### PR DESCRIPTION
This patch aims to restore compatibility with Nextcloud 14 - 19.

- Calls to new methods removed
- Restored old way of adding css files
- Fixed missing personal settings by adding a splash section
- Removed dashboard options on versions that do not have a dashboard

I quickly tested this on NC 14, 19 and 20 and did not notice any additional errors.