### PR TITLE
May fix the "Nextcloud Image" provider (currently not working)

### DIFF
--- a/lib/Provider/NextcloudImage.php
+++ b/lib/Provider/NextcloudImage.php
@@ -26,7 +26,7 @@ use OCA\Unsplash\ProviderHandler\Provider;
 class NextcloudImage extends Provider{
 
     // Todo: Use URLGenerator. See AdminSettingsController
-	private string $THEMING_URL="/index.php/apps/theming/image/background";
+	private string $THEMING_URL="/index.php/apps/theming/img/background";
 	public bool $ALLOW_CUSTOMIZING = false;
 
 	public function getWhitelistResourceUrls(): array


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

On Nextcloud instances, including mine, the default background images are in the "/apps/theming/img/background" folder but not in the "/apps/theming/image/background" folder. I assume that this could fix this provider.

