### PR TITLE
Fix unsplash on login page causing Internal Server Error

### DIFF
--- a/lib/EventListener/BeforeTemplateRenderedEventListener.php
+++ b/lib/EventListener/BeforeTemplateRenderedEventListener.php
@@ -60,7 +60,10 @@ class BeforeTemplateRenderedEventListener implements IEventListener
         switch ($route) {
             case 'core.TwoFactorChallenge.showChallenge':
             case 'files_sharing.Share.authenticate':
+            // Nextcloud <= 28
             case 'core.login.showLoginForm':
+            // Nextcloud >= 29
+            case 'core.login.showloginform':
             case 'files_sharing.Share.showAuthenticate':
                 if ($serverstyleLogin) {
                     $this->addHeaderFor('login');


### PR DESCRIPTION
## Add
* Add route name `core.login.showloginform` for Nextcloud >= 29

## Fixes
- Event of type `BeforeLoginTemplateRenderedEvent` ended up in the default statement because of UpperCamelCase of routine name
- default statement tries to execute `$event->isLoggedIn()` which does not exist for this event
- Causes error and Internal Server Error in UI:
  `[index] Error: Call to undefined method OCP\AppFramework\Http\Events\BeforeLoginTemplateRenderedEvent::isLoggedIn()`

## Tested
- Nextcloud 29.0.5
- Log out and go to Login Page
- Verify no InternalServerError and a random background image is visible

## Issue
closes #139 
closes #141 