### PR TITLE
Add Bing Daily Wallpaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ Show a new colorful image on your Loginscreen every day!
 
 
 ## Features
-| Provider                                                                                                              |
-|:----------------------------------------------------------------------------------------------------------------------|
-| Nextcloud Background                                                                                                  |
-| [Unsplash API](https://unsplash.com/developers)                                                                       |
-| [WallhavenCC](https://wallhaven.cc)                                                                                   |
-| [Wikimedia](https://commons.wikimedia.org/wiki/Main_Page)                                                             |
-| [Wikimedia Picture of the Day](https://commons.wikimedia.org/wiki/Commons:Picture_of_the_day)                         |
+| Provider                                                                                           |
+|:---------------------------------------------------------------------------------------------------|
+| Nextcloud Background                                                                               |
+| [Unsplash API](https://unsplash.com/developers)                                                    |
+| [WallhavenCC](https://wallhaven.cc)                                                                |
+| [Wikimedia](https://commons.wikimedia.org/wiki/Main_Page)                                          |
+| [Wikimedia Picture of the Day](https://commons.wikimedia.org/wiki/Commons:Picture_of_the_day)      |
+| [Bing Wallpaper Picture of the Day](https://bingwallpaper.microsoft.com/mac/en/bing/bing-wallpaper) |
 
 
 ## Settings

--- a/lib/Provider/BingWallpaperDaily.php
+++ b/lib/Provider/BingWallpaperDaily.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2024 Bruce Truth | Bruce Mubangwa <bruce@broosaction.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Unsplash\Provider;
+
+use OC\AppFramework\Http\Request;
+use OCA\Unsplash\ProviderHandler\Provider;
+
+class BingWallpaperDaily extends Provider
+{
+    /**
+     * Indicates whether customization is allowed.
+     * @var bool
+     */
+    public bool $ALLOW_CUSTOMIZING = false;
+
+    /**
+     * Indicates if images are cached.
+     * @var bool
+     */
+    public bool $IS_CACHED = true;
+
+    /**
+     * Default metadata URL for Bing wallpapers.
+     * @var string
+     */
+    public string $DEFAULT_METADATA_URL = 'https://www.bing.com';
+
+
+    /**
+     * Get URLs that are allowed for the Bing wallpaper.
+     *
+     * @return array
+     */
+    public function getWhitelistResourceUrls(): array
+    {
+        return ['https://www.bing.com'];
+    }
+
+    /**
+     * Provide a cached image URL or the latest Bing daily wallpaper.
+     *
+     * @return string
+     */
+    public function getCachedImageURL(): string
+    {
+        return $this->getRandomImageUrl("");
+    }
+
+    public function getRandomImageUrl($size)
+    {
+        return $this->getRandomImageUrlBySearchTerm($this->getRandomSearchTerm(), $size);
+    }
+
+    public function getRandomImageUrlBySearchTerm($search, $size)
+    {
+        // Fetch the daily image JSON from Bing
+        $bing_daily_image_json = file_get_contents('https://www.bing.com/HPImageArchive.aspx?format=js&idx=0&n=1&mkt=en-US');
+        if ($bing_daily_image_json !== false) {
+            $matches = json_decode($bing_daily_image_json);
+            if (isset($matches->images[0]->url)) {
+                // If unable to encode, return the image URL
+                return 'https://www.bing.com' . $matches->images[0]->url;
+            }
+        }
+
+        // Return default image if no Bing image is found
+        return (new NextcloudImage($this->appName, $this->logger, $this->config, $this->appData, "Nextcloud"))->getRandomImageUrl($size);
+    }
+}

--- a/lib/ProviderHandler/ProviderDefinitions.php
+++ b/lib/ProviderHandler/ProviderDefinitions.php
@@ -23,6 +23,7 @@
 
 namespace OCA\Unsplash\ProviderHandler;
 
+use OCA\Unsplash\Provider\BingWallpaperDaily;
 use OCA\Unsplash\Provider\NextcloudImage;
 use OCA\Unsplash\Provider\UnsplashAPI;
 use OCA\Unsplash\Provider\WallhavenCC;
@@ -77,6 +78,7 @@ class ProviderDefinitions
         $tmp[] = new WikimediaCommons($this->appName, $logger, $this->config, $appData, "WikimediaCommons");
         $tmp[] = new WikimediaCommonsDaily($this->appName, $logger, $this->config, $appData, "WikimediaCommons - Picture of the Day");
         $tmp[] = new WallhavenCC($this->appName, $logger, $this->config, $appData, "WallhavenCC");
+        $tmp[] = new BingWallpaperDaily($this->appName, $logger, $this->config, $appData, "Bing Wallpaper - Picture of the Day");
 
         foreach ($tmp as &$value) {
             $this->definitions[$value->getName()] = $value;

--- a/templates/partials/licenceBingWallpaper.php
+++ b/templates/partials/licenceBingWallpaper.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * This file is part of the Unsplash App
+ * and licensed under the AGPL.
+ */
+
+
+$links = [
+    "<a href=\"https://bingwallpaper.microsoft.com/mac/en/bing/bing-wallpaper\" rel=\"noreferrer noopener\" target=\"_blank\">Bing Wallpaper</a>"
+];
+
+print_unescaped($l->t('These images are provided by %s. Each image has it\'s own license.', $links));


### PR DESCRIPTION
This PR introduces the **BingWallpaperDaily** provider class, which fetches daily wallpapers from Bing . It integrates seamlessly into the existing provider framework and includes:

- Data fetching from Bing's API.

- Image URL pursing for performance.

-  Fallbacks in case of API failures.

A raw Bing photo endpoint can be [found here](https://www.bing.com/HPImageArchive.aspx?format=js&idx=0&n=1&mkt=en-US) 

Thank you,
Bruce Truth