### PR TITLE
fix(settings): swap deprecated `style()` for `addStyle()` + fix for missing `user.js` resource

### DIFF
--- a/templates/settings/personal.php
+++ b/templates/settings/personal.php
@@ -4,11 +4,11 @@
  * and licensed under the AGPL.
  */
 
+use OCP\Util;
 
 if (($_['dashboard'] || $_['login']) && ($_['selectedProvider'] != "" || $_['selectedProvider'] != "Nextcloud Image")):
 
-    script('unsplash', 'user');
-    style('unsplash', 'settings');
+    Util::addStyle('unsplash', 'settings');
 
     ?>
 


### PR DESCRIPTION
Also fixes `Could not find resource unsplash/js/user.js to load` error due to referencing to an unused/non-existent script.