### PR TITLE
Update version for NC32 compatibility

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@
     <screenshot>https://raw.githubusercontent.com/nextcloud/unsplash/master/.meta/unsplash-header.jpg</screenshot>
     <dependencies>
         <php min-version="8.0" max-version="8.4"/>
-        <nextcloud min-version="26" max-version="31"/>
+        <nextcloud min-version="26" max-version="32"/>
     </dependencies>
     <settings>
         <admin>OCA\Unsplash\Settings\AdminSettings</admin>


### PR DESCRIPTION
Add NC32 support

I went through the migration guide at https://docs.nextcloud.com/server/stable/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_32.html --> app is not affected

I tested the app with NC32 --> successfully

Closes #169 
Closes #170 