### PR TITLE
Remove PHP and Nextcloud upper version constraints

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@
     <screenshot>https://raw.githubusercontent.com/nextcloud/unsplash/master/.meta/unsplash-header.jpg</screenshot>
     <dependencies>
         <php min-version="8.0"/>
-        <nextcloud min-version="26"/>
+        <nextcloud min-version="26" max-version="99"/>
     </dependencies>
     <settings>
         <admin>OCA\Unsplash\Settings\AdminSettings</admin>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,8 +22,8 @@
     <screenshot>https://raw.githubusercontent.com/nextcloud/unsplash/master/.meta/unsplash.jpg</screenshot>
     <screenshot>https://raw.githubusercontent.com/nextcloud/unsplash/master/.meta/unsplash-header.jpg</screenshot>
     <dependencies>
-        <php min-version="8.0" max-version="8.4"/>
-        <nextcloud min-version="26" max-version="31"/>
+        <php min-version="8.0"/>
+        <nextcloud min-version="26"/>
     </dependencies>
     <settings>
         <admin>OCA\Unsplash\Settings\AdminSettings</admin>


### PR DESCRIPTION
Remove PHP and Nextcloud upper version constraints. Nextcloud releases come out every 3 months. Currently, no known compatibility issue requires forbidding the usage with the latest (and future) releases.
- Later on, if a serious change is required, then we can temporarily forbid the deployment by re-introducing the upper limitation until the solution is provided,..

This PR should resolve nextcloud/server#169 nextcloud/server#170 and similar issues going forward.
and close as a duplicate solution only for the NC32 release: nextcloud/server#171 

@skjnldsv or @joshtrichards : What is your opinion?